### PR TITLE
Only listen on one port for HTTP

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -8,13 +8,11 @@ import (
 
 // Config holds configuration data read from a config file.
 type Config struct {
-	ExternalHost string
-	ExternalPort int
-	InternalHost string
-	InternalPort int
-	Cert         string
-	Key          string
-	Emailer      struct {
+	Host    string
+	Port    int
+	Cert    string
+	Key     string
+	Emailer struct {
 		Token string
 	}
 	Storer struct {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,15 +22,13 @@ func main() {
 	}
 
 	s := server.New(server.Options{
-		Emailer:      createEmailer(c),
-		Storer:       createStorer(c, logger),
-		Logger:       logger,
-		ExternalHost: c.ExternalHost,
-		ExternalPort: c.ExternalPort,
-		InternalHost: c.InternalHost,
-		InternalPort: c.InternalPort,
-		Cert:         c.Cert,
-		Key:          c.Key,
+		Emailer: createEmailer(c),
+		Storer:  createStorer(c, logger),
+		Logger:  logger,
+		Host:    c.Host,
+		Port:    c.Port,
+		Cert:    c.Cert,
+		Key:     c.Key,
 	})
 
 	if err := s.Start(); err != nil {

--- a/development.toml
+++ b/development.toml
@@ -1,7 +1,5 @@
-ExternalHost = "localhost"
-ExternalPort = 2020
-InternalHost = "localhost"
-InternalPort = 2021
+Host = "localhost"
+Port = 2020
 Cert = "cert.pem"
 Key = "key.pem"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - "2020:2020"
-      - "2021:2021"
     depends_on:
       - db
     restart: always

--- a/docker.toml
+++ b/docker.toml
@@ -1,7 +1,5 @@
-ExternalHost = "localhost"
-ExternalPort = 2020
-InternalHost = "localhost"
-InternalPort = 2021
+Host = ""
+Port = 2020
 Cert = "cert.pem"
 Key = "key.pem"
 

--- a/production/etc/ahead.toml
+++ b/production/etc/ahead.toml
@@ -1,2 +1,0 @@
-ExternalPort = 2020
-InternalPort = 2021

--- a/production/etc/caddy/Caddyfile
+++ b/production/etc/caddy/Caddyfile
@@ -5,7 +5,7 @@ app.example.com {
     # to otherhost2:2020
 
     health_path /health
-    health_port 2021
+    health_port 2020
     health_interval 10s
     health_timeout 5s
   }

--- a/server/routes.go
+++ b/server/routes.go
@@ -10,9 +10,9 @@ import (
 	"github.com/maragudk/go-ahead/views"
 )
 
-func (s *Server) setupExternalRoutes() {
+func (s *Server) setupRoutes() {
 	// The views that can be requested by the browser
-	s.externalMux.Group(func(r chi.Router) {
+	s.mux.Group(func(r chi.Router) {
 		r.Use(middleware.Recoverer, handlers.NoClickjacking, handlers.StrictContentSecurityPolicy)
 		r.Use(s.sm.LoadAndSave)
 
@@ -28,7 +28,7 @@ func (s *Server) setupExternalRoutes() {
 	})
 
 	// The REST API
-	s.externalMux.Route("/api", func(r chi.Router) {
+	s.mux.Route("/api", func(r chi.Router) {
 		r.Use(middleware.Recoverer, handlers.JSONHeader)
 		r.Use(s.sm.LoadAndSave)
 
@@ -44,9 +44,12 @@ func (s *Server) setupExternalRoutes() {
 			r.Get("/session", handlers.Session())
 		})
 	})
-}
 
-func (s *Server) setupInternalRoutes() {
-	s.internalMux.Get("/health", handlers.Health(s.Storer))
-	s.internalMux.Get("/metrics", handlers.Metrics())
+	// Health and metrics
+	s.mux.Group(func(r chi.Router) {
+		r.Use(middleware.Recoverer)
+
+		r.Get("/health", handlers.Health(s.Storer))
+		r.Get("/metrics", handlers.Metrics())
+	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,9 +8,8 @@ import (
 
 func TestNewServer(t *testing.T) {
 	t.Run("returns new server with http addresses set", func(t *testing.T) {
-		s := New(Options{ExternalPort: 123, InternalPort: 234, InternalHost: "localhost"})
+		s := New(Options{Port: 123})
 		require.NotNil(t, s)
-		require.Equal(t, ":123", s.externalAddress)
-		require.Equal(t, "localhost:234", s.internalAddress)
+		require.Equal(t, ":123", s.address)
 	})
 }


### PR DESCRIPTION
Gets rid of the external/internal differentiation, for simplicity.